### PR TITLE
fix: channel.queue_declare call due to API change in pika

### DIFF
--- a/stuff/python/liner2rmq.py
+++ b/stuff/python/liner2rmq.py
@@ -26,7 +26,7 @@ class Liner2Rmq:
     def receive(self, route):
         channel = self.connection.channel()
         channel.exchange_declare(exchange=self.output_queue, exchange_type='direct')
-        result = channel.queue_declare(exclusive=True)
+        result = channel.queue_declare(self.output_queue, exclusive=True)
         queue_name = result.method.queue
         channel.queue_bind(exchange=self.output_queue, queue=queue_name, routing_key=route)
         response = next(channel.consume(queue_name))


### PR DESCRIPTION
Pass `self.output_queue` explicitly as it is required in never versions of "pika" (see: https://github.com/pika/pika/pull/941/files#diff-831cec7ce02158498fb9bb8d1fd55451R790)